### PR TITLE
Upgrade to SDK version v0.1.19

### DIFF
--- a/go/Dockerfile.control
+++ b/go/Dockerfile.control
@@ -12,8 +12,8 @@ COPY go.* control.go /go/src/github.com/antithesis/glitch-grid
 
 # Download install and run antithesis-go-generator
 RUN cd /go/src/github.com/antithesis/glitch-grid && \
-    go get github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-generator@v0.1.18 && \
-    go install github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-generator@v0.1.18 && \
+    go get github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-generator@v0.1.19 && \
+    go install github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-generator@v0.1.19 && \
     go mod tidy && \
     go generate
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,4 +4,4 @@ go 1.20
 
 require github.com/golang/glog v1.2.0
 
-require github.com/antithesishq/antithesis-sdk-go v0.1.18
+require github.com/antithesishq/antithesis-sdk-go v0.1.19

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/antithesishq/antithesis-sdk-go v0.1.18 h1:K6eRhORVYc5oOHeM8ym6fDmfsKl5MR9aJIhHQlzjROU=
-github.com/antithesishq/antithesis-sdk-go v0.1.18/go.mod h1:qOiIeVdo1mwCsRgb+mOi7CjgU+zKuPNpUiasOEIqUqw=
+github.com/antithesishq/antithesis-sdk-go v0.1.19 h1:/9/lti2g4iREKTHSD/ETwxbMyWFigY88XPfN5kTX1kI=
+github.com/antithesishq/antithesis-sdk-go v0.1.19/go.mod h1:qOiIeVdo1mwCsRgb+mOi7CjgU+zKuPNpUiasOEIqUqw=
 github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
 github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
SDK v0.1.19 fixes an issue where the native Antithesis libraries would never be loaded, even when running in the Antithesis platform