### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Glitch Grid is a toy distributed system for demonstrating how to
 integrate with the [Antithesis Platform](https://antithesis.com/). This project demonstrates:
 
 * Use of [the Antithesis SDK]((https://antithesis.com/docs/using_antithesis/sdk/overview.html#))
-   to [define properties](https://antithesis.com/docs/using_antithesis/properties.html)
+   to [define properties](https://antithesis.com/docs/using_antithesis/properties/)
 * Instrumenting a Go project for [coverage information](https://antithesis.com/docs/instrumentation/overview.html)
 * Triggering tests and receiving results using [Github Actions](https://antithesis.com/docs/using_antithesis/ci.html)
 


### PR DESCRIPTION
Judging by the rest of the links this one is just missing a redirect from the .html URL, but this also works.