### PR TITLE
make main use antithesis-trigger-action@feature-use-more-params (TEMPORARY)

### DIFF
--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -124,4 +124,5 @@ jobs:
           custom.repo_name=${{github.repository}}
           custom.action_name = ${{github.action}}
           custom.actor = ${{ github.actor }}
+          test_param = "testing"
 

--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -112,20 +112,20 @@ jobs:
     - name: Run Antithesis Tests
       uses: antithesishq/antithesis-trigger-action@feature-use-more-params
       with:
-        notebook_name: demo_go
+        # metadata about what you're running
+        system_name: "Glitch Grid"
+        test_name:  ${{ inputs.test }}
+        team: "Antithesis Demo devs"
+        description: "The CI run for ref - ${{ github.ref_name }} commit # ${{ github.sha }}"
+        # (TODO: pass `on.schedule.cron`)
+
+        # information needed to start a run
         tenant: honey-whale
         username: ${{ secrets.ANTITHESIS_USERNAME }}
         password: ${{ secrets.ANTITHESIS_PASSWORD }}
         github_token: ${{ secrets.GH_PAT }}
+        notebook_name: demo_go
         config_image: demo-go-config@${{ steps.build-push-go-config.outputs.digest }}
         images: docker.io/antithesishq/demo-workload@${{ steps.build-push-go-workload.outputs.digest }};docker.io/antithesishq/demo-go-control@${{ steps.build-push-go-control.outputs.digest }};demo-go-vault@${{ steps.build-push-go-vault.outputs.digest }};
-        description: "The CI run for ref - ${{ github.ref_name }} commit # ${{ github.sha }}"
-        test_name:  ${{ inputs.test }}
         additional_parameters: |-
-          run.team = "Antithesis Demo devs"
-          vcs.system_name = "Glitch Grid"
-          custom.repo_name=${{github.repository}}
-          custom.action_name = ${{github.action}}
-          custom.actor = ${{ github.actor }}
-          test_param = "testing"
-
+          custom.param_name = "Contact us to set up extra parameters."

--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -109,7 +109,7 @@ jobs:
 
     # Run Antithesis Tests
     - name: Run Antithesis Tests
-      uses: antithesishq/antithesis-trigger-action@main
+      uses: antithesishq/antithesis-trigger-action@feature-use-more-params
       with:
         notebook_name: demo_go
         tenant: demo

--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   antithesis:
+    environment: "testing: run on honey-whale"
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -11,11 +11,12 @@ on:
    pull_request:
    workflow_call:
    schedule:
-     - cron: "5 1 * * *"
+    # FIXME: For testing, this is scheduled at every XX:05!
+    # Change it back ASAP to "5 1 * * *" (at every 01:05).
+     - cron: "*/5 * * * *"
 
 jobs:
   antithesis:
-    environment: "testing: run on honey-whale"
     runs-on: ubuntu-latest
 
     permissions:
@@ -110,6 +111,7 @@ jobs:
 
     # Run Antithesis Tests
     - name: Run Antithesis Tests
+      # FIXME: change this back to @main
       uses: antithesishq/antithesis-trigger-action@feature-use-more-params
       with:
         # metadata about what you're running
@@ -120,7 +122,7 @@ jobs:
         cron_schedule: ${{ github.event.schedule }}
 
         # information needed to start a run
-        tenant: honey-whale
+        tenant: demo
         username: ${{ secrets.ANTITHESIS_USERNAME }}
         password: ${{ secrets.ANTITHESIS_PASSWORD }}
         github_token: ${{ secrets.GH_PAT }}
@@ -128,4 +130,7 @@ jobs:
         config_image: demo-go-config@${{ steps.build-push-go-config.outputs.digest }}
         images: docker.io/antithesishq/demo-workload@${{ steps.build-push-go-workload.outputs.digest }};docker.io/antithesishq/demo-go-control@${{ steps.build-push-go-control.outputs.digest }};demo-go-vault@${{ steps.build-push-go-vault.outputs.digest }};
         additional_parameters: |-
+          custom.repo_name = ${{github.repository}}
+          custom.action_name = ${{github.action}}
+          custom.actor = ${{ github.actor }}
           custom.param_name = "Contact us to set up extra parameters."

--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -117,7 +117,7 @@ jobs:
         test_name:  ${{ inputs.test }}
         team: "Antithesis Demo devs"
         description: "The CI run for ref - ${{ github.ref_name }} commit # ${{ github.sha }}"
-        # (TODO: pass `on.schedule.cron`)
+        cron_schedule: ${{ github.event.schedule }}
 
         # information needed to start a run
         tenant: honey-whale

--- a/.github/workflows/ci_integration_go.yml
+++ b/.github/workflows/ci_integration_go.yml
@@ -112,7 +112,7 @@ jobs:
       uses: antithesishq/antithesis-trigger-action@feature-use-more-params
       with:
         notebook_name: demo_go
-        tenant: demo
+        tenant: honey-whale
         username: ${{ secrets.ANTITHESIS_USERNAME }}
         password: ${{ secrets.ANTITHESIS_PASSWORD }}
         github_token: ${{ secrets.GH_PAT }}
@@ -121,6 +121,8 @@ jobs:
         description: "The CI run for ref - ${{ github.ref_name }} commit # ${{ github.sha }}"
         test_name:  ${{ inputs.test }}
         additional_parameters: |-
+          run.team = "Antithesis Demo devs"
+          vcs.system_name = "Glitch Grid"
           custom.repo_name=${{github.repository}}
           custom.action_name = ${{github.action}}
           custom.actor = ${{ github.actor }}

--- a/.github/workflows/launch_debugger.yml
+++ b/.github/workflows/launch_debugger.yml
@@ -37,6 +37,7 @@ jobs:
 
     # Start Antithesis Debugging
     - name: Start Antithesis Debugging
+      # FIXME: change this back to @main
       uses: antithesishq/antithesis-trigger-action@feature-use-more-params
       with:
         notebook_name: launch_debugging 

--- a/.github/workflows/launch_debugger.yml
+++ b/.github/workflows/launch_debugger.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Start Antithesis Debugging
     - name: Start Antithesis Debugging
-      uses: antithesishq/antithesis-trigger-action@main
+      uses: antithesishq/antithesis-trigger-action@feature-use-more-params
       with:
         notebook_name: launch_debugging 
         tenant: demo

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ cython_debug/
 
 # Random but common clutter
 .DS_Store
+.vscode/settings.json


### PR DESCRIPTION
(This is for testing and should be updated/reverted immediately afterwards!)

as of this PR,
- the `on: schedule` Event will happen **way more frequently** (for rapid testing)
- instead of our action's `main` branch, glitch-grid will call my feature branch on it
- add extra params

Changes which can be safely kept in a reversion:
- reorganized params in `jobs: antithesis: with:`
- added `.vscode/settings.json` to .gitignore